### PR TITLE
Handle ansible docs path variants

### DIFF
--- a/dependency-hell.sh
+++ b/dependency-hell.sh
@@ -103,6 +103,15 @@ for branch in $BRANCHES; do
 
     declare -a table
 
+    # Determine ansible docs path
+    if [ -f docs/ansible.md ]; then
+        ANSIBLE_FILE="docs/ansible.md"
+    elif [ -f docs/ansible/ansible.md ]; then
+        ANSIBLE_FILE="docs/ansible/ansible.md"
+    else
+        continue
+    fi
+
     # Extract information from ansible.md
     table=()
     count=1
@@ -129,7 +138,7 @@ for branch in $BRANCHES; do
                 fi
             done
         fi
-    done < docs/ansible.md
+    done < "$ANSIBLE_FILE"
 
     # If the checksums.yml file exists, parse it
     if [ -f $CHECKSUMS_FILE_PATH ]; then


### PR DESCRIPTION
## Summary
- detect which ansible documentation path exists in `dependency-hell.sh`
- use detected path when reading ansible docs

## Testing
- `shellcheck dependency-hell.sh`

------
https://chatgpt.com/codex/tasks/task_e_686cea19b8e4832692a361f85a60cdbd