### PR TITLE
Fix yq missing message output to stderr

### DIFF
--- a/dependency-hell.sh
+++ b/dependency-hell.sh
@@ -3,8 +3,8 @@
 # Ensure yq is installed
 if ! command -v yq &> /dev/null
 then
-    echo "yq could not be found. Please install it first."
-    exit
+    echo "yq could not be found. Please install it first." >&2
+    exit 1
 fi
 
 # Initialize optional parameters


### PR DESCRIPTION
## Summary
- send missing `yq` message to stderr and exit with status 1

## Testing
- `bash -n dependency-hell.sh`


------
https://chatgpt.com/codex/tasks/task_e_686cec77b344832698877d885bfb754c