### PR TITLE
Fix python version parsing whitespace

### DIFF
--- a/dependency-hell.sh
+++ b/dependency-hell.sh
@@ -20,6 +20,8 @@ expand_python_versions() {
     IFS=',' read -ra ADDR <<< "$input_versions"
 
     for version in "${ADDR[@]}"; do
+        # Remove any leading or trailing whitespace from the version entry
+        version=$(echo "$version" | xargs)
         # Check if it's a range or a single version
         if [[ "$version" =~ ^([0-9]+\.[0-9]+)-([0-9]+\.[0-9]+)$ ]]; then
             start_version="${BASH_REMATCH[1]}"


### PR DESCRIPTION
## Summary
- trim whitespace from python version entries when expanding versions

## Testing
- `bash dependency-hell.sh --k8s-version v1.29.0 --python-version 3.8 > /tmp/test_output.txt`


------
https://chatgpt.com/codex/tasks/task_e_686ceeadee548326b14e248490ea6094