### PR TITLE
Add git command availability check

### DIFF
--- a/dependency-hell.sh
+++ b/dependency-hell.sh
@@ -7,6 +7,12 @@ then
     exit
 fi
 
+# Ensure git is installed
+if ! command -v git >/dev/null; then
+    echo "git is required" >&2
+    exit 1
+fi
+
 # Initialize optional parameters
 DESIRED_K8S_VERSION=""
 DESIRED_PYTHON_VERSION=""


### PR DESCRIPTION
## Summary
- check that `git` is installed before running the script

## Testing
- `bash -n dependency-hell.sh`

------
https://chatgpt.com/codex/tasks/task_e_686cf13ec52083269791514da80489b4