### PR TITLE
Add bats tests for helper functions

### DIFF
--- a/tests/expand_python_versions.bats
+++ b/tests/expand_python_versions.bats
@@ -1,0 +1,42 @@
+#!/usr/bin/env bats
+
+setup() {
+    expand_python_versions() {
+        input_versions="$1"
+        expanded_versions=""
+        IFS=',' read -ra ADDR <<< "$input_versions"
+        for version in "${ADDR[@]}"; do
+            if [[ "$version" =~ ^([0-9]+\.[0-9]+)-([0-9]+\.[0-9]+)$ ]]; then
+                start_version="${BASH_REMATCH[1]}"
+                end_version="${BASH_REMATCH[2]}"
+                start_minor=${start_version#*.}
+                end_minor=${end_version#*.}
+                for ((i=start_minor; i<=end_minor; i++)); do
+                    expanded_versions+="${start_version%%.*}.$i, "
+                done
+            else
+                expanded_versions+="$version, "
+            fi
+        done
+        expanded_versions="${expanded_versions%, }"
+        echo "$expanded_versions"
+    }
+}
+
+@test "expand range" {
+    run expand_python_versions "3.7-3.9"
+    [ "$status" -eq 0 ]
+    [ "$output" = "3.7, 3.8, 3.9" ]
+}
+
+@test "expand range and single" {
+    run expand_python_versions "3.7-3.9,3.10"
+    [ "$status" -eq 0 ]
+    [ "$output" = "3.7, 3.8, 3.9, 3.10" ]
+}
+
+@test "preserve whitespace" {
+    run expand_python_versions "3.7-3.9, 3.10"
+    [ "$status" -eq 0 ]
+    [ "$output" = "3.7, 3.8, 3.9,  3.10" ]
+}

--- a/tests/extract_kubectl_versions.bats
+++ b/tests/extract_kubectl_versions.bats
@@ -1,0 +1,37 @@
+#!/usr/bin/env bats
+
+setup() {
+    extract_kubectl_versions() {
+        FILE_PATH=$1
+        if yq e 'has("kubectl_checksums.amd64")' $FILE_PATH > /dev/null && \
+           yq e '.kubectl_checksums.amd64 != null' $FILE_PATH > /dev/null && \
+           yq e '.kubectl_checksums.amd64 | type' $FILE_PATH | grep -q "map"; then
+            yq e '.kubectl_checksums.amd64 | keys | .[]' $FILE_PATH | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | tr '\n' ',' | sed 's/,$//' | sed 's/,/, /g'
+        else
+            echo ""
+        fi
+    }
+}
+
+@test "extract kubectl versions" {
+    cat <<'YML' > tmp.yml
+kubectl_checksums:
+  amd64:
+    v1.19.0: foo
+    v1.20.0: bar
+YML
+    run extract_kubectl_versions tmp.yml
+    [ "$status" -eq 0 ]
+    [ "$output" = "v1.19.0, v1.20.0" ]
+    rm tmp.yml
+}
+
+@test "missing section returns empty" {
+    cat <<'YML' > tmp.yml
+other: value
+YML
+    run extract_kubectl_versions tmp.yml
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+    rm tmp.yml
+}


### PR DESCRIPTION
## Summary
- add tests for expand_python_versions and extract_kubectl_versions

## Testing
- `bats tests`

------
https://chatgpt.com/codex/tasks/task_e_686ce4da9b588326918973b67c6bcd57